### PR TITLE
Use command instead of supervisorctl module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,8 +6,8 @@
 
 - name: reread supervisord
   sudo: yes
-  supervisorctl: reread
+  command: supervisorctl reread
 
 - name: update supervisord
   sudo: yes
-  supervisorctl: update
+  command: supervisorctl update


### PR DESCRIPTION
`reread` and `update` are (no longer?) valid arguments for the `supervisorctl` module
