### PR TITLE
Add newline to chmod and chown directives

### DIFF
--- a/templates/supervisord.conf
+++ b/templates/supervisord.conf
@@ -41,8 +41,10 @@ strip_ansi       = {{'true' if supervisord_strip_ansi_from_child_logs else 'fals
 [unix_http_server] ;-----------------------------------------------------------
 
 file     = {{supervisord_socket_file}} ; Path to the socket file
-{% if supervisord_socket_chmod %}chmod    = {{supervisord_socket_chmod}}{% endif %}
-{% if supervisord_socket_chown %}chown    = {{supervisord_socket_chown}}{% endif %}
+{% if supervisord_socket_chmod %}chmod    = {{supervisord_socket_chmod}}
+{% endif %}
+{% if supervisord_socket_chown %}chown    = {{supervisord_socket_chown}}
+{% endif %}
 {% if supervisord_socket_authenticated %}
 username = {{supervisord_socket_username}}
 password = {{supervisord_socket_username}}


### PR DESCRIPTION
When supervisord_socket_chmod and supervisord_socket_chown are specified, the resulting directives should be on separate lines.