### PR TITLE
Fixed warning in ansible 2.x

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 
 - name: restart supervisord
-  sudo: yes
+  become: yes
   service: name=supervisor state=restarted
 
 - name: reread supervisord
-  sudo: yes
+  become: yes
   command: supervisorctl reread
 
 - name: update supervisord
-  sudo: yes
+  become: yes
   command: supervisorctl update

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,7 +9,7 @@
 #   - `ansible_pkg_mgr`              → apt, yum, ...
 
 - name: Create Supervisor conf and log directories
-  sudo: yes
+  become: yes
   file:
     dest: "{{item}}"
     state: directory
@@ -24,7 +24,7 @@
     - supervisord
 
 - name: Configure Supervisord
-  sudo: yes
+  become: yes
   template:
     src: supervisord.conf
     dest: "{{supervisord_conf_file}}"
@@ -35,7 +35,7 @@
     - supervisord
 
 - name: Link Supervisord conf
-  sudo: yes
+  become: yes
   file:
     src: "{{supervisord_conf_file}}"
     dest: "{{supervisord_conf_file_link}}"
@@ -47,7 +47,7 @@
     - supervisord
 
 - name: Create supervisord init script
-  sudo: yes
+  become: yes
   template:
     src: "{{item}}"
     dest: "{{supervisord_init_script}}"
@@ -67,7 +67,7 @@
     - supervisord
 
 - name: Add supervisord to init
-  sudo: yes
+  become: yes
   service:
     name: "{{supervisord_service_name}}"
     enabled: yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -9,7 +9,7 @@
 #   - `ansible_pkg_mgr`              → apt, yum, ...
 
 - name: Update the packages list
-  sudo: yes
+  become: yes
   when: ansible_os_family == 'Debian'
   apt:
     update_cache: yes
@@ -20,7 +20,7 @@
     - supervisord
 
 - name: Install Supervisord
-  sudo: yes
+  become: yes
   when: ansible_os_family == 'Debian'
   apt:
     name: supervisor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
 - include: configure.yml
 
 - name: Ensure supervisord is running
-  sudo: yes
+  become: yes
   service:
     name: "{{supervisord_service_name}}"
     state: running

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,3 +16,13 @@
     - init
     - supervisor
     - supervisord
+
+- name: Force systemctl enable supervisor ( Bug in ubuntu 16.04 pkg )
+  become: yes
+  command: systemctl enable supervisor
+  when: ansible_os_family == 'Debian'
+  tags:
+    - init
+    - supervisor
+    - supervisord
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   become: yes
   service:
     name: "{{supervisord_service_name}}"
-    state: running
+    state: started
     enabled: yes
   tags:
     - init


### PR DESCRIPTION
Fixed warning in ansible 2.x: Instead of sudo/sudo_user, use become/become_user
