### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   sudo: yes
   service:
     name: "{{supervisord_service_name}}"
-    state: running
+    state: started
     enabled: yes
   tags:
     - init


### PR DESCRIPTION
TASK [ansible-supervisord : Ensure supervisord is running] 
*********************************************************
[DEPRECATION WARNING]: state=running is deprecated. Please use state=started.
This feature will be removed in version 2.7. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.